### PR TITLE
Exclude a file from the readability reports

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -79,4 +79,4 @@ jobs:
             - uses: ./
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  glob: '**/*.md'
+                  glob: '**/!(user-permissions).md'


### PR DESCRIPTION
This pull request excludes a file from the readability reporter.

The excluded file ([user-permissions.md](https://github.com/Rebilly/website/blob/main/docs/settings/user-permissions.md)) contains generated reference content that has a very negative impact on the readability metrics. 