### PR TITLE
dev: Improve the developer commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "build": "rollup -c",
         "test": "jest",
         "format": "prettier --write src/*.js src/**/*.js ./*.js",
-        "run:local": "babel-node ./src/cli",
+        "run:local:report": "babel-node ./src/cli/report",
+        "run:local:debugfile": "babel-node ./src/cli/debug-file.js",
         "lint": "eslint --ext .js ."
     },
     "dependencies": {
@@ -33,6 +34,7 @@
         "@rollup/plugin-node-resolve": "^13.0.0",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^27.0.6",
+        "commander": "^9.4.0",
         "eslint": "^7.29.0",
         "eslint-config-airbnb": "18.2.1",
         "eslint-config-prettier": "^8.3.0",

--- a/src/cli/debug-file.js
+++ b/src/cli/debug-file.js
@@ -1,0 +1,20 @@
+import {Command} from 'commander';
+import fs from 'fs';
+import {preprocessMarkdown} from '../readability'
+
+const program = new Command();
+program
+  .name('debug file')
+  .description('Show what the program parses form a single file, after stripping the junk away')
+
+program
+  .argument('<file>', 'the filepath to show the stripped input for')
+program.parse();
+
+const [, , filePath] = process.argv;
+
+const markdown = fs.readFileSync(filePath);
+const stripped = preprocessMarkdown(markdown);
+
+console.log('------ stripped file input: ------');
+console.log(stripped);

--- a/src/cli/report.js
+++ b/src/cli/report.js
@@ -1,23 +1,35 @@
 import path from 'path';
 import glob from 'glob';
-import {calculateReadability} from './readability';
-import {generateReport} from './report';
-import {reportToComment} from './markdown';
+import {Command} from 'commander';
+import {calculateReadability} from '../readability';
+import {generateReport} from '../report';
+import {reportToComment} from '../markdown';
 
+const program = new Command();
+program
+  .name('report')
+  .description('Show generated report output in console')
+
+program
+  .argument('<oldFolder>', 'old folder to compare to')
+  .argument('<newFolder>', 'new folder to compare to')
+  .option('-g, --glob <pattern>', 'The glob to use when matching files', '**/*.{md,mdx}')
+program.parse();
+
+const GLOB = program.opts().glob
 const [, , oldFolder, newFolder] = process.argv;
 
-const ALL_MD_FILES = '**/*.md';
 const ROOT_DIR = process.cwd();
 
 // Run the readability stats on all MD files in the first folder provided
 process.chdir(path.join(ROOT_DIR, oldFolder));
-const allOldFiles = glob.sync(ALL_MD_FILES);
-const oldReadability = calculateReadability(ALL_MD_FILES);
+const allOldFiles = glob.sync(GLOB);
+const oldReadability = calculateReadability(GLOB);
 
 // Run the readability stats on all MD files in the second folder provided
 process.chdir(path.join(ROOT_DIR, newFolder));
-const allNewFiles = glob.sync(ALL_MD_FILES);
-const newReadability = calculateReadability(ALL_MD_FILES);
+const allNewFiles = glob.sync(GLOB);
+const newReadability = calculateReadability(GLOB);
 
 // We dont have a real PR, so generate modified/added files based
 // on the difference of files in the input folders

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,9 +1776,9 @@ camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001241"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz#cd3fae47eb3d7691692b406568d7a3e5b23c7598"
-  integrity sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==
+  version "1.0.30001400"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz"
+  integrity sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -1895,6 +1895,11 @@ commander@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
+commander@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
+  integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
 
 commondir@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR improves the developer commands:
- Renames `run:local` to `run:local:report`
  - allows `--glob` to be passed, so you can specify which files to check. Updated the default to include `.mdx` files, too.
- Adds new command: `run:local:debugfile` which is used like `run:local:debugfile ./path/to/file.md` to show the input the readability tool is processing