### PR TITLE
Remove manual line breaks from file inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,13 @@ jobs:
 | `lint`      | Run eslint on all files                                                                                                                                                                                                                         |
 | `format`    | Run prettier on all files                                                                                                                                                                                                                       |
 | `build`     | build the dist file. You are required to run this locally in order to build the dist before opening a PR.                                                                                                                                       |
-| `run:local` | Run the action on two local folders, for testing and development. The first argument is the old ("base branch") folder and the sedcond argument is the new ("head branch") folder. For example `yarn run:local ./test-data/old ./test-data/new` |
+| `run:local:report` | Run the action on two local folders, for testing and development. The first argument is the old ("base branch") folder and the sedcond argument is the new ("head branch") folder. For example `yarn run:local:report ./test-data/old ./test-data/new` |
+| `run:local:debugfile` | Show what the program parses from a single file, after stripping all non-wanted items from the file, and before rating the readability. For example `yarn run:local:debugfile ./test-data/new/test-document.md` |
 
 ### Testing
 
 When developing the action, it can be useful to be able to run it locally rather than pushing a branch and running your development version on GitHub.
 
-You can test the action locally by running the `run:local` command. This will report readability on two different folders, as if they were a pull request.
+You can test the action locally by running the `run:local:report` command. This will report readability on two different folders, as if they were a pull request.
 
-For example: `yarn run:local ./test-data/old ./test-data/new`
+For example: `yarn run:local:report ./test-data/old ./test-data/new`

--- a/dist/index.js
+++ b/dist/index.js
@@ -30606,7 +30606,9 @@ function averageObjectProperties(objects) {
 function preprocessMarkdown(markdown) {
   var remarker = remark().use(removeShortListItems).use(removeHeadings).use(removeAdmonitionHeadings).use(removeImageAltText).use(removeCodeBlocks).use(removePageMetadata).use(removeJsItems).use(stripMarkdown);
   return remarker.processSync(markdown).contents // Remove any blank lines
-  .replace(/\n+/g, "\n");
+  .replace(/\n+/g, "\n") // Remove any new lines that are added for manual word wrapping.
+  // Here we just presume these will be preceeded by a normal alphabetical character
+  .replace(/([a-zA-Z])\n/g, '$1 ');
 } // Calculate the readabilty result for all files found in a given path glob.
 // This result contains readability scores for each file, and an overall average
 

--- a/src/cli/debug-file.js
+++ b/src/cli/debug-file.js
@@ -5,7 +5,7 @@ import {preprocessMarkdown} from '../readability'
 const program = new Command();
 program
   .name('debug file')
-  .description('Show what the program parses form a single file, after stripping the junk away')
+  .description('Show what the program parses from a single file, after stripping the junk away')
 
 program
   .argument('<file>', 'the filepath to show the stripped input for')

--- a/src/readability.js
+++ b/src/readability.js
@@ -95,8 +95,6 @@ const removeJsItems = () => (tree) => {
             }
         })
     })
-
-
 }
 
 // Returns scores for a given string
@@ -146,8 +144,12 @@ export function preprocessMarkdown(markdown) {
 
     return remarker
         .processSync(markdown)
-        .contents // Remove any blank lines
-        .replace(/\n+/g, `\n`);
+        .contents
+        // Remove any blank lines
+        .replace(/\n+/g, `\n`)
+        // Remove any new lines that are added for manual word wrapping.
+        // Here we just presume these will be preceeded by a normal alphabetical character
+        .replace(/([a-zA-Z])\n/g, '$1 ');
 }
 
 // Calculate the readabilty result for all files found in a given path glob.

--- a/src/readability.test.js
+++ b/src/readability.test.js
@@ -114,4 +114,34 @@ Some content. This is paragraph with const items = \\\\[];
 "
 `);
     });
+
+    it('should remove manual linebreaks', () => {
+        const stripped = preprocessMarkdown(
+            `
+This test has lines
+that are manually spaced
+out by their writer.
+It should not remove new lines
+that are from different sentences.
+
+Lists of items should not be affected either:
+- Here is list item number 1.
+- Here is list item number 2.
+- Here is list item number 3.
+
+More text after the list.
+`
+        );
+
+        expect(stripped).toMatchInlineSnapshot(`
+            "This test has lines that are manually spaced out by their writer.
+            It should not remove new lines that are from different sentences.
+            Lists of items should not be affected either:
+            Here is list item number 1.
+            Here is list item number 2.
+            Here is list item number 3.
+            More text after the list.
+            "
+        `);
+    });
 });


### PR DESCRIPTION
This PR removes manual line breaks from file inputs.

These can negatively affect the CLI and LWF scores.