### PR TITLE
Use unified readability score

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/** -diff linguist-generated=true 

--- a/README.md
+++ b/README.md
@@ -4,37 +4,47 @@ This action reports readability scores and their changes for Markdown files in y
 
 <details>
   <summary>See example pull request comment</summary>
+**Overall readability score:** 20.18/100 (🟢 +0.97)
 
-Readability after merging this PR:
+File | Readability
+--- | ---
+[README.md](https://github.com/Rebilly/readability-reporter/blob/cce569da633a092c0a9b09bc1fe6d3df1b4dcb26/README.md "README.md") | 22.36 (🟢 +3.86)
+
 
 <details>
-  <summary>View Metric Targets</summary>
+  <summary>View detailed metrics</summary>
 
-| Metric                 | Range                                                  | Ideal score |
-| ---------------------- |--------------------------------------------------------| ----------- |
-| Flesch Reading Ease    | 100 (very easy read) to 0 (extremely difficult read)   | 60          |
-| Gunning Fog            | 6 (very easy read) to 17 (extremely difficult read)    | 8 or less   |
-| SMOG Index             | 6 (very easy read) to 14 (extremely difficult read)    | 8 or less   |
-| Auto. Read. Index      | 6 (very easy read) to 14 (extremely difficult read)    | 8 or less   |
-| Coleman Liau Index     | 6 (very easy read) to 17 (extremely difficult read)    | 8 or less   |
-| Linsear Write          | 0 (very easy read) to 11 (extremely difficult read)    | 8 or less   |
-| Dale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less |
+🟢 - Shows an _increase_ in readability
+🔴 - Shows a _decrease_ in readability
+
+File | Readability | FRE | GF | ARI | CLI | DCRS
+--- | --- | --- | --- | --- | --- | ---
+[README.md](https://github.com/Rebilly/readability-reporter/blob/cce569da633a092c0a9b09bc1fe6d3df1b4dcb26/README.md "README.md") | 22.36 | 44.11 | 16.67 | 28.7 | 11.85 | 7.66
+&nbsp; | 🟢 +3.86 | 🟢 +2.03 | 🟢 +0.75 | 🟢 +2.2 | 🔴 -0.7 | 🟢 +0.01
+
+
+Averages:
+
+&nbsp; | Readability | FRE | GF | ARI | CLI | DCRS
+--- | --- | --- | --- | --- | --- | ---
+Average | 20.18 | 14 | 16.94 | 19.17 | 15.11 | 9.52
+&nbsp; | 🟢 +0.97 | 🟢 +0.51 | 🟢 +0.19 | 🟢 +0.55 | 🔴 -0.17 | 🟢 +0
+
+
+<details>
+  <summary>View metric targets</summary>
+
+Metric | Range | Ideal score
+--- | --- | ---
+Flesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60
+Gunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less
+Auto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less
+Coleman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less
+Dale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less
 
 </details>
 
-| Path                                 | FRE      | GF       | SMOG    | ARI     | CLI      | LWF     | DCRS     |
-| ------------------------------------ | -------- | -------- | ------- | ------- | -------- | ------- | -------- |
-| [README.md](# 'README.md')           | 45.15    | 10.16    | 13.4    | 21.7    | 11.77    | 15.3    | 7.42     |
-| &nbsp;                               | 🔴 -9.78 | 🟢 -1.26 | 🔴 +2.2 | 🟢 -1.2 | 🔴 +1.04 | 🔴 +1.8 | 🟢 -1.21 |
-| [new-feature.md](# 'new-feature.md') | 5.15     | 14.23    | 0       | 13.7    | 17.35    | 5.5     | 10.75    |
-| &nbsp;                               | -        | -        | -       | -       | -        | -       | -        |
-
-Overall average:
-
-&nbsp; | FRE | GF | SMOG | ARI | CLI | LWF | DCRS
---- | --- | --- | --- | --- | --- | --- | ---
-Average | 17.52 | 13.73 | 12.35 | 16.6 | 14.91 | 12.95 | 8.71
-&nbsp; | 🔴 -37.41 | 🔴 +2.31 | 🔴 +1.15 | 🟢 -6.3 | 🔴 +4.18 | 🟢 -0.55 | 🔴 +0.08
+</details>
 
 </details>
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -30586,7 +30586,7 @@ function scoreText(text) {
     // The CLI index can be NaN for some texts, so ensure it's 0
     colemanLiauIndex: Number.isNaN(colemanLiauIndex) ? 0 : colemanLiauIndex
   };
-} // Returns scores for a given string
+} // Returns each score normalized to a value between 0 and 1
 
 
 function normalizeScores(scores) {
@@ -30626,7 +30626,7 @@ function normalizeScores(scores) {
   };
 }
 
-function createOverallReadabilityScore(normalizeScores) {
+function calculateReadabilityScore(normalizeScores) {
   var weights = {
     fleschReadingEase: 0.1653977378,
     gunningFog: 0.2228367277,
@@ -30674,11 +30674,11 @@ function calculateReadability(globPath) {
     var stripped = preprocessMarkdown(markdown);
     var scores = scoreText(stripped);
     var normalized = normalizeScores(scores);
-    var overallReadabilityScore = createOverallReadabilityScore(normalized);
+    var readabilityScore = calculateReadabilityScore(normalized);
     return {
       name: filePath,
       scores: _objectSpread$1({
-        overallReadabilityScore: overallReadabilityScore
+        readabilityScore: readabilityScore
       }, scores)
     };
   });
@@ -30833,16 +30833,16 @@ var addNegativeDiffMarker = function addNegativeDiffMarker(value) {
 // as link, using the result of that function as the target
 
 
-var resultToOverallReadabilityRowWithDiff = function resultToOverallReadabilityRowWithDiff(result, nameToLinkFunction) {
+var resultToReadabilityRowWithDiff = function resultToReadabilityRowWithDiff(result, nameToLinkFunction) {
   var _addPositiveDiffMarke, _result$diff;
 
   var name = result.name,
       scores = result.scores;
   var filenameOnly = require$$0__default$1['default'].basename(name);
   var displayName = nameToLinkFunction ? "[".concat(filenameOnly, "](").concat(nameToLinkFunction(name), " \"").concat(name, "\")") : name;
-  var overallScore = roundValue(scores.overallReadabilityScore);
-  var diff = (_addPositiveDiffMarke = addPositiveDiffMarker(roundValue((_result$diff = result.diff) === null || _result$diff === void 0 ? void 0 : _result$diff.overallReadabilityScore))) !== null && _addPositiveDiffMarke !== void 0 ? _addPositiveDiffMarke : '-';
-  return [displayName, "".concat(overallScore, " (").concat(diff, ")")];
+  var readabilityScore = roundValue(scores.readabilityScore);
+  var diff = (_addPositiveDiffMarke = addPositiveDiffMarker(roundValue((_result$diff = result.diff) === null || _result$diff === void 0 ? void 0 : _result$diff.readabilityScore))) !== null && _addPositiveDiffMarke !== void 0 ? _addPositiveDiffMarke : '-';
+  return [displayName, "".concat(readabilityScore, " (").concat(diff, ")")];
 }; // Returns a table row showing the absolute scores for a given result object.
 // If a nameToLinkFunction is passed, the result name will be created
 // as link, using the result of that function as the target
@@ -30853,7 +30853,7 @@ var resultToScoreTableRow = function resultToScoreTableRow(result, nameToLinkFun
       scores = result.scores;
   var filenameOnly = require$$0__default$1['default'].basename(name);
   var displayName = nameToLinkFunction ? "[".concat(filenameOnly, "](").concat(nameToLinkFunction(name), " \"").concat(name, "\")") : name;
-  return [displayName, roundValue(scores.overallReadabilityScore), roundValue(scores.fleschReadingEase), roundValue(scores.gunningFog), roundValue(scores.automatedReadabilityIndex), roundValue(scores.colemanLiauIndex), roundValue(scores.daleChallReadabilityScore)];
+  return [displayName, roundValue(scores.readabilityScore), roundValue(scores.fleschReadingEase), roundValue(scores.gunningFog), roundValue(scores.automatedReadabilityIndex), roundValue(scores.colemanLiauIndex), roundValue(scores.daleChallReadabilityScore)];
 }; // Returns a table row showing the difference in scores for a given result object.
 
 
@@ -30861,7 +30861,7 @@ var resultToDiffTableRow = function resultToDiffTableRow(result) {
   var _addPositiveDiffMarke2, _addPositiveDiffMarke3, _addNegativeDiffMarke, _addNegativeDiffMarke2, _addNegativeDiffMarke3, _addNegativeDiffMarke4;
 
   var diff = result.diff;
-  return ['&nbsp;', (_addPositiveDiffMarke2 = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.overallReadabilityScore))) !== null && _addPositiveDiffMarke2 !== void 0 ? _addPositiveDiffMarke2 : '-', (_addPositiveDiffMarke3 = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.fleschReadingEase))) !== null && _addPositiveDiffMarke3 !== void 0 ? _addPositiveDiffMarke3 : '-', (_addNegativeDiffMarke = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.gunningFog))) !== null && _addNegativeDiffMarke !== void 0 ? _addNegativeDiffMarke : '-', (_addNegativeDiffMarke2 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.automatedReadabilityIndex))) !== null && _addNegativeDiffMarke2 !== void 0 ? _addNegativeDiffMarke2 : '-', (_addNegativeDiffMarke3 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.colemanLiauIndex))) !== null && _addNegativeDiffMarke3 !== void 0 ? _addNegativeDiffMarke3 : '-', (_addNegativeDiffMarke4 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.daleChallReadabilityScore))) !== null && _addNegativeDiffMarke4 !== void 0 ? _addNegativeDiffMarke4 : '-'];
+  return ['&nbsp;', (_addPositiveDiffMarke2 = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.readabilityScore))) !== null && _addPositiveDiffMarke2 !== void 0 ? _addPositiveDiffMarke2 : '-', (_addPositiveDiffMarke3 = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.fleschReadingEase))) !== null && _addPositiveDiffMarke3 !== void 0 ? _addPositiveDiffMarke3 : '-', (_addNegativeDiffMarke = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.gunningFog))) !== null && _addNegativeDiffMarke !== void 0 ? _addNegativeDiffMarke : '-', (_addNegativeDiffMarke2 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.automatedReadabilityIndex))) !== null && _addNegativeDiffMarke2 !== void 0 ? _addNegativeDiffMarke2 : '-', (_addNegativeDiffMarke3 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.colemanLiauIndex))) !== null && _addNegativeDiffMarke3 !== void 0 ? _addNegativeDiffMarke3 : '-', (_addNegativeDiffMarke4 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.daleChallReadabilityScore))) !== null && _addNegativeDiffMarke4 !== void 0 ? _addNegativeDiffMarke4 : '-'];
 }; // Convert a report object to a markdown comment
 
 
@@ -30876,13 +30876,13 @@ var reportToComment = function reportToComment(_ref2) {
     return "https://github.com/".concat(repository, "/blob/").concat(commit, "/").concat(name);
   };
 
-  var overallReadabilityTable = tableToMD({
+  var readabilityTable = tableToMD({
     headers: ['Path', 'Readability'],
     rows: report.fileResults.map(function (result) {
-      return resultToOverallReadabilityRowWithDiff(result, nameToLink);
+      return resultToReadabilityRowWithDiff(result, nameToLink);
     })
   });
-  var fileTable = tableToMD({
+  var detailedFileTable = tableToMD({
     headers: ['Path', 'Readability', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
     rows: report.fileResults.flatMap(function (result) {
       return [resultToScoreTableRow(result, nameToLink), resultToDiffTableRow(result)];
@@ -30892,9 +30892,9 @@ var reportToComment = function reportToComment(_ref2) {
     headers: ['&nbsp;', 'Readability', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
     rows: [resultToScoreTableRow(report.averageResult[0]), resultToDiffTableRow(report.averageResult[0])]
   });
-  var overallReadability = roundValue(report.averageResult[0].scores.overallReadabilityScore);
-  var overallReadabilityDiff = addPositiveDiffMarker(roundValue(report.averageResult[0].diff.overallReadabilityScore));
-  return "\nReadability after merging this PR: ".concat(overallReadability, "/100 (").concat(overallReadabilityDiff, ")\n\n").concat(overallReadabilityTable, "\n\n<details>\n  <summary>View Detailed Metrics</summary>\n\n\uD83D\uDFE2 - Shows an _increase_ in readability\n\uD83D\uDD34 - Shows a _decrease_ in readability\n\n").concat(fileTable, "\n\nOverall average:\n\n").concat(averageTable, "\n\n<details>\n  <summary>View Metric Targets</summary>\n\nMetric | Range | Ideal score\n--- | --- | ---\nFlesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60\nGunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nAuto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less\nColeman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nDale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less\n\n</details>\n\n</details>\n");
+  var averageReadability = roundValue(report.averageResult[0].scores.readabilityScore);
+  var averageReadabilityDiff = addPositiveDiffMarker(roundValue(report.averageResult[0].diff.readabilityScore));
+  return "\nReadability after merging this PR: ".concat(averageReadability, "/100 (").concat(averageReadabilityDiff, ")\n\n").concat(readabilityTable, "\n\n<details>\n  <summary>View Detailed Metrics</summary>\n\n\uD83D\uDFE2 - Shows an _increase_ in readability\n\uD83D\uDD34 - Shows a _decrease_ in readability\n\n").concat(detailedFileTable, "\n\nAverages:\n\n").concat(averageTable, "\n\n<details>\n  <summary>View Metric Targets</summary>\n\nMetric | Range | Ideal score\n--- | --- | ---\nFlesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60\nGunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nAuto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less\nColeman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nDale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less\n\n</details>\n\n</details>\n");
 };
 
 var main = /*#__PURE__*/function () {

--- a/dist/index.js
+++ b/dist/index.js
@@ -30633,8 +30633,11 @@ function createOverallReadabilityScore(normalizeScores) {
     automatedReadabilityIndex: 0.2325290236,
     daleChallReadabilityScore: 0.1960641698,
     colemanLiauIndex: 0.1831723411
-  };
-  return normalizeScores.fleschReadingEase * weights.fleschReadingEase + normalizeScores.gunningFog * weights.gunningFog + normalizeScores.automatedReadabilityIndex * weights.automatedReadabilityIndex + normalizeScores.daleChallReadabilityScore * weights.daleChallReadabilityScore + normalizeScores.colemanLiauIndex * weights.colemanLiauIndex;
+  }; // The reability score from 0 to 1.0
+
+  var normalizedReadabilityScore = normalizeScores.fleschReadingEase * weights.fleschReadingEase + normalizeScores.gunningFog * weights.gunningFog + normalizeScores.automatedReadabilityIndex * weights.automatedReadabilityIndex + normalizeScores.daleChallReadabilityScore * weights.daleChallReadabilityScore + normalizeScores.colemanLiauIndex * weights.colemanLiauIndex; // Scale the score from 0 to 100
+
+  return 100 * normalizedReadabilityScore;
 } // Calculates the average of a particular property value, given an array of objects
 
 
@@ -30825,6 +30828,21 @@ var addNegativeDiffMarker = function addNegativeDiffMarker(value) {
   }
 
   return value;
+}; // Returns a table row showing the absolute scores and  for a given result object.
+// If a nameToLinkFunction is passed, the result name will be created
+// as link, using the result of that function as the target
+
+
+var resultToOverallReadabilityRowWithDiff = function resultToOverallReadabilityRowWithDiff(result, nameToLinkFunction) {
+  var _addPositiveDiffMarke, _result$diff;
+
+  var name = result.name,
+      scores = result.scores;
+  var filenameOnly = require$$0__default$1['default'].basename(name);
+  var displayName = nameToLinkFunction ? "[".concat(filenameOnly, "](").concat(nameToLinkFunction(name), " \"").concat(name, "\")") : name;
+  var overallScore = roundValue(scores.overallReadabilityScore);
+  var diff = (_addPositiveDiffMarke = addPositiveDiffMarker(roundValue((_result$diff = result.diff) === null || _result$diff === void 0 ? void 0 : _result$diff.overallReadabilityScore))) !== null && _addPositiveDiffMarke !== void 0 ? _addPositiveDiffMarke : '-';
+  return [displayName, "".concat(overallScore, " (").concat(diff, ")")];
 }; // Returns a table row showing the absolute scores for a given result object.
 // If a nameToLinkFunction is passed, the result name will be created
 // as link, using the result of that function as the target
@@ -30840,10 +30858,10 @@ var resultToScoreTableRow = function resultToScoreTableRow(result, nameToLinkFun
 
 
 var resultToDiffTableRow = function resultToDiffTableRow(result) {
-  var _addPositiveDiffMarke, _addPositiveDiffMarke2, _addNegativeDiffMarke, _addNegativeDiffMarke2, _addNegativeDiffMarke3, _addNegativeDiffMarke4;
+  var _addPositiveDiffMarke2, _addPositiveDiffMarke3, _addNegativeDiffMarke, _addNegativeDiffMarke2, _addNegativeDiffMarke3, _addNegativeDiffMarke4;
 
   var diff = result.diff;
-  return ['&nbsp;', (_addPositiveDiffMarke = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.overallReadabilityScore))) !== null && _addPositiveDiffMarke !== void 0 ? _addPositiveDiffMarke : '-', (_addPositiveDiffMarke2 = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.fleschReadingEase))) !== null && _addPositiveDiffMarke2 !== void 0 ? _addPositiveDiffMarke2 : '-', (_addNegativeDiffMarke = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.gunningFog))) !== null && _addNegativeDiffMarke !== void 0 ? _addNegativeDiffMarke : '-', (_addNegativeDiffMarke2 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.automatedReadabilityIndex))) !== null && _addNegativeDiffMarke2 !== void 0 ? _addNegativeDiffMarke2 : '-', (_addNegativeDiffMarke3 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.colemanLiauIndex))) !== null && _addNegativeDiffMarke3 !== void 0 ? _addNegativeDiffMarke3 : '-', (_addNegativeDiffMarke4 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.daleChallReadabilityScore))) !== null && _addNegativeDiffMarke4 !== void 0 ? _addNegativeDiffMarke4 : '-'];
+  return ['&nbsp;', (_addPositiveDiffMarke2 = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.overallReadabilityScore))) !== null && _addPositiveDiffMarke2 !== void 0 ? _addPositiveDiffMarke2 : '-', (_addPositiveDiffMarke3 = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.fleschReadingEase))) !== null && _addPositiveDiffMarke3 !== void 0 ? _addPositiveDiffMarke3 : '-', (_addNegativeDiffMarke = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.gunningFog))) !== null && _addNegativeDiffMarke !== void 0 ? _addNegativeDiffMarke : '-', (_addNegativeDiffMarke2 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.automatedReadabilityIndex))) !== null && _addNegativeDiffMarke2 !== void 0 ? _addNegativeDiffMarke2 : '-', (_addNegativeDiffMarke3 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.colemanLiauIndex))) !== null && _addNegativeDiffMarke3 !== void 0 ? _addNegativeDiffMarke3 : '-', (_addNegativeDiffMarke4 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.daleChallReadabilityScore))) !== null && _addNegativeDiffMarke4 !== void 0 ? _addNegativeDiffMarke4 : '-'];
 }; // Convert a report object to a markdown comment
 
 
@@ -30858,17 +30876,25 @@ var reportToComment = function reportToComment(_ref2) {
     return "https://github.com/".concat(repository, "/blob/").concat(commit, "/").concat(name);
   };
 
+  var overallReadabilityTable = tableToMD({
+    headers: ['Path', 'Readability'],
+    rows: report.fileResults.map(function (result) {
+      return resultToOverallReadabilityRowWithDiff(result, nameToLink);
+    })
+  });
   var fileTable = tableToMD({
-    headers: ['Path', 'Overall', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
+    headers: ['Path', 'Readability', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
     rows: report.fileResults.flatMap(function (result) {
       return [resultToScoreTableRow(result, nameToLink), resultToDiffTableRow(result)];
     })
   });
   var averageTable = tableToMD({
-    headers: ['&nbsp;', 'Overall', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
+    headers: ['&nbsp;', 'Readability', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
     rows: [resultToScoreTableRow(report.averageResult[0]), resultToDiffTableRow(report.averageResult[0])]
   });
-  return "\nReadability after merging this PR:\n\n<details>\n  <summary>View Metric Targets</summary>\n\nMetric | Range | Ideal score\n--- | --- | ---\nFlesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60\nGunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nAuto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less\nColeman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nDale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less\n\n</details>\n\n\uD83D\uDFE2 - Shows an _increase_ in readability\n\uD83D\uDD34 - Shows a _decrease_ in readability\n\n".concat(fileTable, "\n\nOverall average:\n\n").concat(averageTable, "\n");
+  var overallReadability = roundValue(report.averageResult[0].scores.overallReadabilityScore);
+  var overallReadabilityDiff = addPositiveDiffMarker(roundValue(report.averageResult[0].diff.overallReadabilityScore));
+  return "\nReadability after merging this PR: ".concat(overallReadability, "/100 (").concat(overallReadabilityDiff, ")\n\n").concat(overallReadabilityTable, "\n\n<details>\n  <summary>View Detailed Metrics</summary>\n\n\uD83D\uDFE2 - Shows an _increase_ in readability\n\uD83D\uDD34 - Shows a _decrease_ in readability\n\n").concat(fileTable, "\n\nOverall average:\n\n").concat(averageTable, "\n\n<details>\n  <summary>View Metric Targets</summary>\n\nMetric | Range | Ideal score\n--- | --- | ---\nFlesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60\nGunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nAuto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less\nColeman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nDale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less\n\n</details>\n\n</details>\n");
 };
 
 var main = /*#__PURE__*/function () {

--- a/dist/index.js
+++ b/dist/index.js
@@ -30626,7 +30626,7 @@ function normalizeScores(scores) {
   };
 }
 
-function calculateReadabilityScore(normalizeScores) {
+function calculateReadabilityScore(normalizedScores) {
   var weights = {
     fleschReadingEase: 0.1653977378,
     gunningFog: 0.2228367277,
@@ -30635,7 +30635,7 @@ function calculateReadabilityScore(normalizeScores) {
     colemanLiauIndex: 0.1831723411
   }; // The reability score from 0 to 1.0
 
-  var normalizedReadabilityScore = normalizeScores.fleschReadingEase * weights.fleschReadingEase + normalizeScores.gunningFog * weights.gunningFog + normalizeScores.automatedReadabilityIndex * weights.automatedReadabilityIndex + normalizeScores.daleChallReadabilityScore * weights.daleChallReadabilityScore + normalizeScores.colemanLiauIndex * weights.colemanLiauIndex; // Scale the score from 0 to 100
+  var normalizedReadabilityScore = normalizedScores.fleschReadingEase * weights.fleschReadingEase + normalizedScores.gunningFog * weights.gunningFog + normalizedScores.automatedReadabilityIndex * weights.automatedReadabilityIndex + normalizedScores.daleChallReadabilityScore * weights.daleChallReadabilityScore + normalizedScores.colemanLiauIndex * weights.colemanLiauIndex; // Scale the score from 0 to 100
 
   return 100 * normalizedReadabilityScore;
 } // Calculates the average of a particular property value, given an array of objects

--- a/dist/index.js
+++ b/dist/index.js
@@ -30835,15 +30835,15 @@ var resultToScoreTableRow = function resultToScoreTableRow(result, nameToLinkFun
       scores = result.scores;
   var filenameOnly = require$$0__default$1['default'].basename(name);
   var displayName = nameToLinkFunction ? "[".concat(filenameOnly, "](").concat(nameToLinkFunction(name), " \"").concat(name, "\")") : name;
-  return [displayName, roundValue(scores.overallReadabilityScore), roundValue(scores.fleschReadingEase), roundValue(scores.gunningFog), roundValue(scores.smogIndex), roundValue(scores.automatedReadabilityIndex), roundValue(scores.colemanLiauIndex), roundValue(scores.linsearWriteFormula), roundValue(scores.daleChallReadabilityScore)];
+  return [displayName, roundValue(scores.overallReadabilityScore), roundValue(scores.fleschReadingEase), roundValue(scores.gunningFog), roundValue(scores.automatedReadabilityIndex), roundValue(scores.colemanLiauIndex), roundValue(scores.daleChallReadabilityScore)];
 }; // Returns a table row showing the difference in scores for a given result object.
 
 
 var resultToDiffTableRow = function resultToDiffTableRow(result) {
-  var _addPositiveDiffMarke, _addPositiveDiffMarke2, _addNegativeDiffMarke, _addNegativeDiffMarke2, _addNegativeDiffMarke3, _addNegativeDiffMarke4, _addNegativeDiffMarke5, _addNegativeDiffMarke6;
+  var _addPositiveDiffMarke, _addPositiveDiffMarke2, _addNegativeDiffMarke, _addNegativeDiffMarke2, _addNegativeDiffMarke3, _addNegativeDiffMarke4;
 
   var diff = result.diff;
-  return ['&nbsp;', (_addPositiveDiffMarke = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.overallReadabilityScore))) !== null && _addPositiveDiffMarke !== void 0 ? _addPositiveDiffMarke : '-', (_addPositiveDiffMarke2 = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.fleschReadingEase))) !== null && _addPositiveDiffMarke2 !== void 0 ? _addPositiveDiffMarke2 : '-', (_addNegativeDiffMarke = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.gunningFog))) !== null && _addNegativeDiffMarke !== void 0 ? _addNegativeDiffMarke : '-', (_addNegativeDiffMarke2 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.smogIndex))) !== null && _addNegativeDiffMarke2 !== void 0 ? _addNegativeDiffMarke2 : '-', (_addNegativeDiffMarke3 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.automatedReadabilityIndex))) !== null && _addNegativeDiffMarke3 !== void 0 ? _addNegativeDiffMarke3 : '-', (_addNegativeDiffMarke4 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.colemanLiauIndex))) !== null && _addNegativeDiffMarke4 !== void 0 ? _addNegativeDiffMarke4 : '-', (_addNegativeDiffMarke5 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.linsearWriteFormula))) !== null && _addNegativeDiffMarke5 !== void 0 ? _addNegativeDiffMarke5 : '-', (_addNegativeDiffMarke6 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.daleChallReadabilityScore))) !== null && _addNegativeDiffMarke6 !== void 0 ? _addNegativeDiffMarke6 : '-'];
+  return ['&nbsp;', (_addPositiveDiffMarke = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.overallReadabilityScore))) !== null && _addPositiveDiffMarke !== void 0 ? _addPositiveDiffMarke : '-', (_addPositiveDiffMarke2 = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.fleschReadingEase))) !== null && _addPositiveDiffMarke2 !== void 0 ? _addPositiveDiffMarke2 : '-', (_addNegativeDiffMarke = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.gunningFog))) !== null && _addNegativeDiffMarke !== void 0 ? _addNegativeDiffMarke : '-', (_addNegativeDiffMarke2 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.automatedReadabilityIndex))) !== null && _addNegativeDiffMarke2 !== void 0 ? _addNegativeDiffMarke2 : '-', (_addNegativeDiffMarke3 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.colemanLiauIndex))) !== null && _addNegativeDiffMarke3 !== void 0 ? _addNegativeDiffMarke3 : '-', (_addNegativeDiffMarke4 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.daleChallReadabilityScore))) !== null && _addNegativeDiffMarke4 !== void 0 ? _addNegativeDiffMarke4 : '-'];
 }; // Convert a report object to a markdown comment
 
 
@@ -30859,16 +30859,16 @@ var reportToComment = function reportToComment(_ref2) {
   };
 
   var fileTable = tableToMD({
-    headers: ['Path', 'Overall', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
+    headers: ['Path', 'Overall', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
     rows: report.fileResults.flatMap(function (result) {
       return [resultToScoreTableRow(result, nameToLink), resultToDiffTableRow(result)];
     })
   });
   var averageTable = tableToMD({
-    headers: ['&nbsp;', 'Overall', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
+    headers: ['&nbsp;', 'Overall', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
     rows: [resultToScoreTableRow(report.averageResult[0]), resultToDiffTableRow(report.averageResult[0])]
   });
-  return "\nReadability after merging this PR:\n\n<details>\n  <summary>View Metric Targets</summary>\n\nMetric | Range | Ideal score\n--- | --- | ---\nFlesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60\nGunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nSMOG Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less\nAuto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less\nColeman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nLinsear Write | 0 (very easy read) to 11 (extremely difficult read) | 8 or less\nDale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less\n\n</details>\n\n\uD83D\uDFE2 - Shows an _increase_ in readability\n\uD83D\uDD34 - Shows a _decrease_ in readability\n\n".concat(fileTable, "\n\nOverall average:\n\n").concat(averageTable, "\n");
+  return "\nReadability after merging this PR:\n\n<details>\n  <summary>View Metric Targets</summary>\n\nMetric | Range | Ideal score\n--- | --- | ---\nFlesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60\nGunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nAuto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less\nColeman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nDale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less\n\n</details>\n\n\uD83D\uDFE2 - Shows an _increase_ in readability\n\uD83D\uDD34 - Shows a _decrease_ in readability\n\n".concat(fileTable, "\n\nOverall average:\n\n").concat(averageTable, "\n");
 };
 
 var main = /*#__PURE__*/function () {

--- a/dist/index.js
+++ b/dist/index.js
@@ -5214,7 +5214,7 @@ var distNode$1 = {};
 
 Object.defineProperty(distNode$1, '__esModule', { value: true });
 
-function ownKeys$3(object, enumerableOnly) {
+function ownKeys$4(object, enumerableOnly) {
   var keys = Object.keys(object);
 
   if (Object.getOwnPropertySymbols) {
@@ -5237,13 +5237,13 @@ function _objectSpread2$1(target) {
     var source = arguments[i] != null ? arguments[i] : {};
 
     if (i % 2) {
-      ownKeys$3(Object(source), true).forEach(function (key) {
+      ownKeys$4(Object(source), true).forEach(function (key) {
         _defineProperty$2(target, key, source[key]);
       });
     } else if (Object.getOwnPropertyDescriptors) {
       Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
     } else {
-      ownKeys$3(Object(source)).forEach(function (key) {
+      ownKeys$4(Object(source)).forEach(function (key) {
         Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
       });
     }
@@ -6473,7 +6473,7 @@ Object.defineProperty(distNode, '__esModule', { value: true });
 
 const VERSION = "2.13.6";
 
-function ownKeys$2(object, enumerableOnly) {
+function ownKeys$3(object, enumerableOnly) {
   var keys = Object.keys(object);
 
   if (Object.getOwnPropertySymbols) {
@@ -6496,13 +6496,13 @@ function _objectSpread2(target) {
     var source = arguments[i] != null ? arguments[i] : {};
 
     if (i % 2) {
-      ownKeys$2(Object(source), true).forEach(function (key) {
+      ownKeys$3(Object(source), true).forEach(function (key) {
         _defineProperty$1(target, key, source[key]);
       });
     } else if (Object.getOwnPropertyDescriptors) {
       Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
     } else {
-      ownKeys$2(Object(source)).forEach(function (key) {
+      ownKeys$3(Object(source)).forEach(function (key) {
         Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
       });
     }
@@ -8033,9 +8033,9 @@ function _defineProperty(obj, key, value) {
   return obj;
 }
 
-function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
+function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread$1(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$1(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$1(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread$2(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$2(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$2(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 // Modified from: https://github.com/slavcodev/coverage-monitor-action
 // Every comment written by our action will have this hidden
@@ -8055,7 +8055,7 @@ var listComments = /*#__PURE__*/function () {
           case 0:
             client = _ref.client, context = _ref.context, prNumber = _ref.prNumber, hiddenHeader = _ref.hiddenHeader;
             _context.next = 3;
-            return client.rest.issues.listComments(_objectSpread$1(_objectSpread$1({}, context.repo), {}, {
+            return client.rest.issues.listComments(_objectSpread$2(_objectSpread$2({}, context.repo), {}, {
               issue_number: prNumber
             }));
 
@@ -8085,7 +8085,7 @@ var insertComment = function insertComment(_ref4, hiddenHeader) {
       context = _ref4.context,
       prNumber = _ref4.prNumber,
       body = _ref4.body;
-  return client.rest.issues.createComment(_objectSpread$1(_objectSpread$1({}, context.repo), {}, {
+  return client.rest.issues.createComment(_objectSpread$2(_objectSpread$2({}, context.repo), {}, {
     issue_number: prNumber,
     body: appendHiddenHeaderToComment(body, hiddenHeader)
   }));
@@ -8096,7 +8096,7 @@ var updateComment = function updateComment(_ref5, hiddenHeader) {
       context = _ref5.context,
       body = _ref5.body,
       commentId = _ref5.commentId;
-  return client.rest.issues.updateComment(_objectSpread$1(_objectSpread$1({}, context.repo), {}, {
+  return client.rest.issues.updateComment(_objectSpread$2(_objectSpread$2({}, context.repo), {}, {
     comment_id: commentId,
     body: appendHiddenHeaderToComment(body, hiddenHeader)
   }));
@@ -8108,7 +8108,7 @@ var deleteComments = function deleteComments(_ref6) {
       comments = _ref6.comments;
   return Promise.all(comments.map(function (_ref7) {
     var id = _ref7.id;
-    return client.rest.issues.deleteComment(_objectSpread$1(_objectSpread$1({}, context.repo), {}, {
+    return client.rest.issues.deleteComment(_objectSpread$2(_objectSpread$2({}, context.repo), {}, {
       comment_id: id
     }));
   }));
@@ -8176,7 +8176,7 @@ var getFileStatusesFromPR = /*#__PURE__*/function () {
           case 0:
             client = _ref10.client, context = _ref10.context, prNumber = _ref10.prNumber;
             _context3.next = 3;
-            return client.rest.pulls.listFiles(_objectSpread$1(_objectSpread$1({}, context.repo), {}, {
+            return client.rest.pulls.listFiles(_objectSpread$2(_objectSpread$2({}, context.repo), {}, {
               pull_number: prNumber,
               // Pull the maximum number of files.
               // For PRs with over 100 files, we will have too many files which will create
@@ -30457,6 +30457,9 @@ class Readability {
 const readability = new Readability();
 var main$1 = readability;
 
+function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread$1(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$1(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$1(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 // Generally our headings are short and do not contribute in a
 // meaningful way to our readability scores
 
@@ -30583,6 +30586,55 @@ function scoreText(text) {
     // The CLI index can be NaN for some texts, so ensure it's 0
     colemanLiauIndex: Number.isNaN(colemanLiauIndex) ? 0 : colemanLiauIndex
   };
+} // Returns scores for a given string
+
+
+function normalizeScores(scores) {
+  var ranges = {
+    fleschReadingEase: {
+      min: 0,
+      max: 100
+    },
+    gunningFog: {
+      min: 19,
+      max: 6
+    },
+    automatedReadabilityIndex: {
+      min: 22,
+      max: 6
+    },
+    daleChallReadabilityScore: {
+      min: 11,
+      max: 4.9
+    },
+    colemanLiauIndex: {
+      min: 19,
+      max: 6
+    }
+  };
+
+  var normalize = function normalize(range, value) {
+    return (value - range.min) / (range.max - range.min);
+  };
+
+  return {
+    fleschReadingEase: normalize(ranges.fleschReadingEase, scores.fleschReadingEase),
+    gunningFog: normalize(ranges.gunningFog, scores.gunningFog),
+    automatedReadabilityIndex: normalize(ranges.automatedReadabilityIndex, scores.automatedReadabilityIndex),
+    daleChallReadabilityScore: normalize(ranges.daleChallReadabilityScore, scores.daleChallReadabilityScore),
+    colemanLiauIndex: normalize(ranges.colemanLiauIndex, scores.colemanLiauIndex)
+  };
+}
+
+function createOverallReadabilityScore(normalizeScores) {
+  var weights = {
+    fleschReadingEase: 0.1653977378,
+    gunningFog: 0.2228367277,
+    automatedReadabilityIndex: 0.2325290236,
+    daleChallReadabilityScore: 0.1960641698,
+    colemanLiauIndex: 0.1831723411
+  };
+  return normalizeScores.fleschReadingEase * weights.fleschReadingEase + normalizeScores.gunningFog * weights.gunningFog + normalizeScores.automatedReadabilityIndex * weights.automatedReadabilityIndex + normalizeScores.daleChallReadabilityScore * weights.daleChallReadabilityScore + normalizeScores.colemanLiauIndex * weights.colemanLiauIndex;
 } // Calculates the average of a particular property value, given an array of objects
 
 
@@ -30618,9 +30670,13 @@ function calculateReadability(globPath) {
     var markdown = require$$0__default['default'].readFileSync(filePath);
     var stripped = preprocessMarkdown(markdown);
     var scores = scoreText(stripped);
+    var normalized = normalizeScores(scores);
+    var overallReadabilityScore = createOverallReadabilityScore(normalized);
     return {
       name: filePath,
-      scores: scores
+      scores: _objectSpread$1({
+        overallReadabilityScore: overallReadabilityScore
+      }, scores)
     };
   });
   var averageResult = [{
@@ -30779,15 +30835,15 @@ var resultToScoreTableRow = function resultToScoreTableRow(result, nameToLinkFun
       scores = result.scores;
   var filenameOnly = require$$0__default$1['default'].basename(name);
   var displayName = nameToLinkFunction ? "[".concat(filenameOnly, "](").concat(nameToLinkFunction(name), " \"").concat(name, "\")") : name;
-  return [displayName, roundValue(scores.fleschReadingEase), roundValue(scores.gunningFog), roundValue(scores.smogIndex), roundValue(scores.automatedReadabilityIndex), roundValue(scores.colemanLiauIndex), roundValue(scores.linsearWriteFormula), roundValue(scores.daleChallReadabilityScore)];
+  return [displayName, roundValue(scores.overallReadabilityScore), roundValue(scores.fleschReadingEase), roundValue(scores.gunningFog), roundValue(scores.smogIndex), roundValue(scores.automatedReadabilityIndex), roundValue(scores.colemanLiauIndex), roundValue(scores.linsearWriteFormula), roundValue(scores.daleChallReadabilityScore)];
 }; // Returns a table row showing the difference in scores for a given result object.
 
 
 var resultToDiffTableRow = function resultToDiffTableRow(result) {
-  var _addPositiveDiffMarke, _addNegativeDiffMarke, _addNegativeDiffMarke2, _addNegativeDiffMarke3, _addNegativeDiffMarke4, _addNegativeDiffMarke5, _addNegativeDiffMarke6;
+  var _addPositiveDiffMarke, _addPositiveDiffMarke2, _addNegativeDiffMarke, _addNegativeDiffMarke2, _addNegativeDiffMarke3, _addNegativeDiffMarke4, _addNegativeDiffMarke5, _addNegativeDiffMarke6;
 
   var diff = result.diff;
-  return ['&nbsp;', (_addPositiveDiffMarke = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.fleschReadingEase))) !== null && _addPositiveDiffMarke !== void 0 ? _addPositiveDiffMarke : '-', (_addNegativeDiffMarke = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.gunningFog))) !== null && _addNegativeDiffMarke !== void 0 ? _addNegativeDiffMarke : '-', (_addNegativeDiffMarke2 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.smogIndex))) !== null && _addNegativeDiffMarke2 !== void 0 ? _addNegativeDiffMarke2 : '-', (_addNegativeDiffMarke3 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.automatedReadabilityIndex))) !== null && _addNegativeDiffMarke3 !== void 0 ? _addNegativeDiffMarke3 : '-', (_addNegativeDiffMarke4 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.colemanLiauIndex))) !== null && _addNegativeDiffMarke4 !== void 0 ? _addNegativeDiffMarke4 : '-', (_addNegativeDiffMarke5 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.linsearWriteFormula))) !== null && _addNegativeDiffMarke5 !== void 0 ? _addNegativeDiffMarke5 : '-', (_addNegativeDiffMarke6 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.daleChallReadabilityScore))) !== null && _addNegativeDiffMarke6 !== void 0 ? _addNegativeDiffMarke6 : '-'];
+  return ['&nbsp;', (_addPositiveDiffMarke = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.overallReadabilityScore))) !== null && _addPositiveDiffMarke !== void 0 ? _addPositiveDiffMarke : '-', (_addPositiveDiffMarke2 = addPositiveDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.fleschReadingEase))) !== null && _addPositiveDiffMarke2 !== void 0 ? _addPositiveDiffMarke2 : '-', (_addNegativeDiffMarke = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.gunningFog))) !== null && _addNegativeDiffMarke !== void 0 ? _addNegativeDiffMarke : '-', (_addNegativeDiffMarke2 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.smogIndex))) !== null && _addNegativeDiffMarke2 !== void 0 ? _addNegativeDiffMarke2 : '-', (_addNegativeDiffMarke3 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.automatedReadabilityIndex))) !== null && _addNegativeDiffMarke3 !== void 0 ? _addNegativeDiffMarke3 : '-', (_addNegativeDiffMarke4 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.colemanLiauIndex))) !== null && _addNegativeDiffMarke4 !== void 0 ? _addNegativeDiffMarke4 : '-', (_addNegativeDiffMarke5 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.linsearWriteFormula))) !== null && _addNegativeDiffMarke5 !== void 0 ? _addNegativeDiffMarke5 : '-', (_addNegativeDiffMarke6 = addNegativeDiffMarker(roundValue(diff === null || diff === void 0 ? void 0 : diff.daleChallReadabilityScore))) !== null && _addNegativeDiffMarke6 !== void 0 ? _addNegativeDiffMarke6 : '-'];
 }; // Convert a report object to a markdown comment
 
 
@@ -30803,13 +30859,13 @@ var reportToComment = function reportToComment(_ref2) {
   };
 
   var fileTable = tableToMD({
-    headers: ['Path', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
+    headers: ['Path', 'Overall', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
     rows: report.fileResults.flatMap(function (result) {
       return [resultToScoreTableRow(result, nameToLink), resultToDiffTableRow(result)];
     })
   });
   var averageTable = tableToMD({
-    headers: ['&nbsp;', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
+    headers: ['&nbsp;', 'Overall', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
     rows: [resultToScoreTableRow(report.averageResult[0]), resultToDiffTableRow(report.averageResult[0])]
   });
   return "\nReadability after merging this PR:\n\n<details>\n  <summary>View Metric Targets</summary>\n\nMetric | Range | Ideal score\n--- | --- | ---\nFlesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60\nGunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nSMOG Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less\nAuto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less\nColeman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nLinsear Write | 0 (very easy read) to 11 (extremely difficult read) | 8 or less\nDale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less\n\n</details>\n\n\uD83D\uDFE2 - Shows an _increase_ in readability\n\uD83D\uDD34 - Shows a _decrease_ in readability\n\n".concat(fileTable, "\n\nOverall average:\n\n").concat(averageTable, "\n");

--- a/dist/index.js
+++ b/dist/index.js
@@ -30816,15 +30816,17 @@ var addPositiveDiffMarker = function addPositiveDiffMarker(value) {
 }; // Adds an emoji marker to a value.
 // If the value is NEGATIVE, we consider it a good value
 // and add a positive marker, otherwise a negative marker
+// We also flip the value to be positive, so that postive
+// scores always show a + sign.
 
 
 var addNegativeDiffMarker = function addNegativeDiffMarker(value) {
   if (typeof value !== 'undefined') {
     if (value === 0 || value < 0) {
-      return "\uD83D\uDFE2 ".concat(value);
+      return "\uD83D\uDFE2 +".concat(-value);
     }
 
-    return "\uD83D\uDD34 +".concat(value);
+    return "\uD83D\uDD34 ".concat(-value);
   }
 
   return value;
@@ -30877,13 +30879,13 @@ var reportToComment = function reportToComment(_ref2) {
   };
 
   var readabilityTable = tableToMD({
-    headers: ['Path', 'Readability'],
+    headers: ['File', 'Readability'],
     rows: report.fileResults.map(function (result) {
       return resultToReadabilityRowWithDiff(result, nameToLink);
     })
   });
   var detailedFileTable = tableToMD({
-    headers: ['Path', 'Readability', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
+    headers: ['File', 'Readability', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
     rows: report.fileResults.flatMap(function (result) {
       return [resultToScoreTableRow(result, nameToLink), resultToDiffTableRow(result)];
     })
@@ -30894,7 +30896,7 @@ var reportToComment = function reportToComment(_ref2) {
   });
   var averageReadability = roundValue(report.averageResult[0].scores.readabilityScore);
   var averageReadabilityDiff = addPositiveDiffMarker(roundValue(report.averageResult[0].diff.readabilityScore));
-  return "\nReadability after merging this PR: ".concat(averageReadability, "/100 (").concat(averageReadabilityDiff, ")\n\n").concat(readabilityTable, "\n\n<details>\n  <summary>View Detailed Metrics</summary>\n\n\uD83D\uDFE2 - Shows an _increase_ in readability\n\uD83D\uDD34 - Shows a _decrease_ in readability\n\n").concat(detailedFileTable, "\n\nAverages:\n\n").concat(averageTable, "\n\n<details>\n  <summary>View Metric Targets</summary>\n\nMetric | Range | Ideal score\n--- | --- | ---\nFlesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60\nGunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nAuto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less\nColeman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nDale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less\n\n</details>\n\n</details>\n");
+  return "\n**Overall readability score:** ".concat(averageReadability, "/100 (").concat(averageReadabilityDiff, ")\n\n").concat(readabilityTable, "\n\n<details>\n  <summary>View detailed metrics</summary>\n\n\uD83D\uDFE2 - Shows an _increase_ in readability\n\uD83D\uDD34 - Shows a _decrease_ in readability\n\n").concat(detailedFileTable, "\n\nAverages:\n\n").concat(averageTable, "\n\n<details>\n  <summary>View metric targets</summary>\n\nMetric | Range | Ideal score\n--- | --- | ---\nFlesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60\nGunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nAuto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less\nColeman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less\nDale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less\n\n</details>\n\n</details>\n");
 };
 
 var main = /*#__PURE__*/function () {

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -48,19 +48,19 @@ const addNegativeDiffMarker = (value) => {
 // Returns a table row showing the absolute scores and  for a given result object.
 // If a nameToLinkFunction is passed, the result name will be created
 // as link, using the result of that function as the target
-const resultToOverallReadabilityRowWithDiff = (result, nameToLinkFunction) => {
+const resultToReadabilityRowWithDiff = (result, nameToLinkFunction) => {
     const {name, scores} = result;
     const filenameOnly = path.basename(name);
     const displayName = nameToLinkFunction
         ? `[${filenameOnly}](${nameToLinkFunction(name)} "${name}")`
         : name;
 
-    const overallScore = roundValue(scores.overallReadabilityScore);
-    const diff = addPositiveDiffMarker(roundValue(result.diff?.overallReadabilityScore)) ?? '-';
+    const readabilityScore = roundValue(scores.readabilityScore);
+    const diff = addPositiveDiffMarker(roundValue(result.diff?.readabilityScore)) ?? '-';
 
     return [
         displayName,
-        `${overallScore} (${diff})`,
+        `${readabilityScore} (${diff})`,
     ];
 };
 
@@ -76,7 +76,7 @@ const resultToScoreTableRow = (result, nameToLinkFunction) => {
 
     return [
         displayName,
-        roundValue(scores.overallReadabilityScore),
+        roundValue(scores.readabilityScore),
         roundValue(scores.fleschReadingEase),
         roundValue(scores.gunningFog),
         roundValue(scores.automatedReadabilityIndex),
@@ -90,7 +90,7 @@ const resultToDiffTableRow = (result) => {
     const {diff} = result;
     return [
         '&nbsp;',
-        addPositiveDiffMarker(roundValue(diff?.overallReadabilityScore)) ?? '-',
+        addPositiveDiffMarker(roundValue(diff?.readabilityScore)) ?? '-',
         addPositiveDiffMarker(roundValue(diff?.fleschReadingEase)) ?? '-',
         addNegativeDiffMarker(roundValue(diff?.gunningFog)) ?? '-',
         addNegativeDiffMarker(roundValue(diff?.automatedReadabilityIndex)) ??
@@ -110,14 +110,14 @@ export const reportToComment = ({
     const nameToLink = (name) =>
         `https://github.com/${repository}/blob/${commit}/${name}`;
 
-    const overallReadabilityTable = tableToMD({
+    const readabilityTable = tableToMD({
         headers: ['Path', 'Readability'],
         rows: report.fileResults.map((result) => 
-            resultToOverallReadabilityRowWithDiff(result, nameToLink),
+            resultToReadabilityRowWithDiff(result, nameToLink),
         ),
     });
 
-    const fileTable = tableToMD({
+    const detailedFileTable = tableToMD({
         headers: ['Path', 'Readability', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
         rows: report.fileResults.flatMap((result) => [
             resultToScoreTableRow(result, nameToLink),
@@ -133,13 +133,13 @@ export const reportToComment = ({
         ],
     });
 
-    const overallReadability = roundValue(report.averageResult[0].scores.overallReadabilityScore);
-    const overallReadabilityDiff = addPositiveDiffMarker(roundValue(report.averageResult[0].diff.overallReadabilityScore));
+    const averageReadability = roundValue(report.averageResult[0].scores.readabilityScore);
+    const averageReadabilityDiff = addPositiveDiffMarker(roundValue(report.averageResult[0].diff.readabilityScore));
 
     return `
-Readability after merging this PR: ${overallReadability}/100 (${overallReadabilityDiff})
+Readability after merging this PR: ${averageReadability}/100 (${averageReadabilityDiff})
 
-${overallReadabilityTable}
+${readabilityTable}
 
 <details>
   <summary>View Detailed Metrics</summary>
@@ -147,9 +147,9 @@ ${overallReadabilityTable}
 🟢 - Shows an _increase_ in readability
 🔴 - Shows a _decrease_ in readability
 
-${fileTable}
+${detailedFileTable}
 
-Overall average:
+Averages:
 
 ${averageTable}
 

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -60,10 +60,8 @@ const resultToScoreTableRow = (result, nameToLinkFunction) => {
         roundValue(scores.overallReadabilityScore),
         roundValue(scores.fleschReadingEase),
         roundValue(scores.gunningFog),
-        roundValue(scores.smogIndex),
         roundValue(scores.automatedReadabilityIndex),
         roundValue(scores.colemanLiauIndex),
-        roundValue(scores.linsearWriteFormula),
         roundValue(scores.daleChallReadabilityScore),
     ];
 };
@@ -76,11 +74,9 @@ const resultToDiffTableRow = (result) => {
         addPositiveDiffMarker(roundValue(diff?.overallReadabilityScore)) ?? '-',
         addPositiveDiffMarker(roundValue(diff?.fleschReadingEase)) ?? '-',
         addNegativeDiffMarker(roundValue(diff?.gunningFog)) ?? '-',
-        addNegativeDiffMarker(roundValue(diff?.smogIndex)) ?? '-',
         addNegativeDiffMarker(roundValue(diff?.automatedReadabilityIndex)) ??
             '-',
         addNegativeDiffMarker(roundValue(diff?.colemanLiauIndex)) ?? '-',
-        addNegativeDiffMarker(roundValue(diff?.linsearWriteFormula)) ?? '-',
         addNegativeDiffMarker(roundValue(diff?.daleChallReadabilityScore)) ??
             '-',
     ];
@@ -96,7 +92,7 @@ export const reportToComment = ({
         `https://github.com/${repository}/blob/${commit}/${name}`;
 
     const fileTable = tableToMD({
-        headers: ['Path', 'Overall', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
+        headers: ['Path', 'Overall', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
         rows: report.fileResults.flatMap((result) => [
             resultToScoreTableRow(result, nameToLink),
             resultToDiffTableRow(result),
@@ -104,7 +100,7 @@ export const reportToComment = ({
     });
 
     const averageTable = tableToMD({
-        headers: ['&nbsp;', 'Overall', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
+        headers: ['&nbsp;', 'Overall', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
         rows: [
             resultToScoreTableRow(report.averageResult[0]),
             resultToDiffTableRow(report.averageResult[0]),
@@ -121,10 +117,8 @@ Metric | Range | Ideal score
 --- | --- | ---
 Flesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60
 Gunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less
-SMOG Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less
 Auto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less
 Coleman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less
-Linsear Write | 0 (very easy read) to 11 (extremely difficult read) | 8 or less
 Dale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less
 
 </details>

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -57,6 +57,7 @@ const resultToScoreTableRow = (result, nameToLinkFunction) => {
 
     return [
         displayName,
+        roundValue(scores.overallReadabilityScore),
         roundValue(scores.fleschReadingEase),
         roundValue(scores.gunningFog),
         roundValue(scores.smogIndex),
@@ -72,6 +73,7 @@ const resultToDiffTableRow = (result) => {
     const {diff} = result;
     return [
         '&nbsp;',
+        addPositiveDiffMarker(roundValue(diff?.overallReadabilityScore)) ?? '-',
         addPositiveDiffMarker(roundValue(diff?.fleschReadingEase)) ?? '-',
         addNegativeDiffMarker(roundValue(diff?.gunningFog)) ?? '-',
         addNegativeDiffMarker(roundValue(diff?.smogIndex)) ?? '-',
@@ -94,7 +96,7 @@ export const reportToComment = ({
         `https://github.com/${repository}/blob/${commit}/${name}`;
 
     const fileTable = tableToMD({
-        headers: ['Path', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
+        headers: ['Path', 'Overall', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
         rows: report.fileResults.flatMap((result) => [
             resultToScoreTableRow(result, nameToLink),
             resultToDiffTableRow(result),
@@ -102,7 +104,7 @@ export const reportToComment = ({
     });
 
     const averageTable = tableToMD({
-        headers: ['&nbsp;', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
+        headers: ['&nbsp;', 'Overall', 'FRE', 'GF', 'SMOG', 'ARI', 'CLI', 'LWF', 'DCRS'],
         rows: [
             resultToScoreTableRow(report.averageResult[0]),
             resultToDiffTableRow(report.averageResult[0]),

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -35,12 +35,14 @@ const addPositiveDiffMarker = (value) => {
 // Adds an emoji marker to a value.
 // If the value is NEGATIVE, we consider it a good value
 // and add a positive marker, otherwise a negative marker
+// We also flip the value to be positive, so that postive
+// scores always show a + sign.
 const addNegativeDiffMarker = (value) => {
     if (typeof value !== 'undefined') {
         if (value === 0 || value < 0) {
-            return `🟢 ${value}`;
+            return `🟢 +${-value}`;
         }
-        return `🔴 +${value}`;
+        return `🔴 ${-value}`;
     }
     return value;
 };
@@ -111,14 +113,14 @@ export const reportToComment = ({
         `https://github.com/${repository}/blob/${commit}/${name}`;
 
     const readabilityTable = tableToMD({
-        headers: ['Path', 'Readability'],
+        headers: ['File', 'Readability'],
         rows: report.fileResults.map((result) => 
             resultToReadabilityRowWithDiff(result, nameToLink),
         ),
     });
 
     const detailedFileTable = tableToMD({
-        headers: ['Path', 'Readability', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
+        headers: ['File', 'Readability', 'FRE', 'GF', 'ARI', 'CLI', 'DCRS'],
         rows: report.fileResults.flatMap((result) => [
             resultToScoreTableRow(result, nameToLink),
             resultToDiffTableRow(result),
@@ -137,12 +139,12 @@ export const reportToComment = ({
     const averageReadabilityDiff = addPositiveDiffMarker(roundValue(report.averageResult[0].diff.readabilityScore));
 
     return `
-Readability after merging this PR: ${averageReadability}/100 (${averageReadabilityDiff})
+**Overall readability score:** ${averageReadability}/100 (${averageReadabilityDiff})
 
 ${readabilityTable}
 
 <details>
-  <summary>View Detailed Metrics</summary>
+  <summary>View detailed metrics</summary>
 
 🟢 - Shows an _increase_ in readability
 🔴 - Shows a _decrease_ in readability
@@ -154,7 +156,7 @@ Averages:
 ${averageTable}
 
 <details>
-  <summary>View Metric Targets</summary>
+  <summary>View metric targets</summary>
 
 Metric | Range | Ideal score
 --- | --- | ---

--- a/src/markdown.test.js
+++ b/src/markdown.test.js
@@ -47,9 +47,9 @@ describe('reportToComment', () => {
 
         expect(reportToComment({report})).toMatchInlineSnapshot(`
             "
-            Readability after merging this PR: 1/100 (🟢 +1)
+            **Overall readability score:** 1/100 (🟢 +1)
 
-            Path | Readability
+            File | Readability
             --- | ---
             [file-1.md](https://github.com/repo-name/blob/commit-sha/./folder/file-1.md \\"./folder/file-1.md\\") | 10 (🟢 +1)
             [file-2.md](https://github.com/repo-name/blob/commit-sha/./folder/file-2.md \\"./folder/file-2.md\\") | 5 (🔴 -1)
@@ -58,19 +58,19 @@ describe('reportToComment', () => {
 
 
             <details>
-              <summary>View Detailed Metrics</summary>
+              <summary>View detailed metrics</summary>
 
             🟢 - Shows an _increase_ in readability
             🔴 - Shows a _decrease_ in readability
 
-            Path | Readability | FRE | GF | ARI | CLI | DCRS
+            File | Readability | FRE | GF | ARI | CLI | DCRS
             --- | --- | --- | --- | --- | --- | ---
             [file-1.md](https://github.com/repo-name/blob/commit-sha/./folder/file-1.md \\"./folder/file-1.md\\") | 10 | 10 | 10 | 10 | 10 | 10
-            &nbsp; | 🟢 +1 | 🟢 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1
+            &nbsp; | 🟢 +1 | 🟢 +1 | 🔴 -1 | 🔴 -1 | 🔴 -1 | 🔴 -1
             [file-2.md](https://github.com/repo-name/blob/commit-sha/./folder/file-2.md \\"./folder/file-2.md\\") | 5 | 5 | 5 | 5 | 5 | 5
-            &nbsp; | 🔴 -1 | 🔴 -1 | 🟢 -1 | 🟢 -1 | 🟢 -1 | 🟢 -1
+            &nbsp; | 🔴 -1 | 🔴 -1 | 🟢 +1 | 🟢 +1 | 🟢 +1 | 🟢 +1
             [file-3.md](https://github.com/repo-name/blob/commit-sha/./folder/file-3.md \\"./folder/file-3.md\\") | 15 | 15 | 15 | 15 | 15 | 15
-            &nbsp; | 🟢 +0 | 🟢 +0 | 🟢 0 | 🟢 0 | 🟢 0 | 🟢 0
+            &nbsp; | 🟢 +0 | 🟢 +0 | 🟢 +0 | 🟢 +0 | 🟢 +0 | 🟢 +0
             [new-file.md](https://github.com/repo-name/blob/commit-sha/./folder/new-file.md \\"./folder/new-file.md\\") | 20 | 20 | 20 | 20 | 20 | 20
             &nbsp; | - | - | - | - | - | -
 
@@ -80,11 +80,11 @@ describe('reportToComment', () => {
             &nbsp; | Readability | FRE | GF | ARI | CLI | DCRS
             --- | --- | --- | --- | --- | --- | ---
             Average | 1 | 1 | 1 | 1 | 1 | 1
-            &nbsp; | 🟢 +1 | 🟢 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1
+            &nbsp; | 🟢 +1 | 🟢 +1 | 🔴 -1 | 🔴 -1 | 🔴 -1 | 🔴 -1
 
 
             <details>
-              <summary>View Metric Targets</summary>
+              <summary>View metric targets</summary>
 
             Metric | Range | Ideal score
             --- | --- | ---

--- a/src/markdown.test.js
+++ b/src/markdown.test.js
@@ -1,6 +1,7 @@
 import {reportToComment} from './markdown';
 
 const mockScores = (value) => ({
+    readabilityScore: value,
     fleschReadingEase: value,
     gunningFog: value,
     smogIndex: value,
@@ -46,7 +47,41 @@ describe('reportToComment', () => {
 
         expect(reportToComment({report})).toMatchInlineSnapshot(`
             "
-            Readability after merging this PR:
+            Readability after merging this PR: 1/100 (🟢 +1)
+
+            Path | Readability
+            --- | ---
+            [file-1.md](https://github.com/repo-name/blob/commit-sha/./folder/file-1.md \\"./folder/file-1.md\\") | 10 (🟢 +1)
+            [file-2.md](https://github.com/repo-name/blob/commit-sha/./folder/file-2.md \\"./folder/file-2.md\\") | 5 (🔴 -1)
+            [file-3.md](https://github.com/repo-name/blob/commit-sha/./folder/file-3.md \\"./folder/file-3.md\\") | 15 (🟢 +0)
+            [new-file.md](https://github.com/repo-name/blob/commit-sha/./folder/new-file.md \\"./folder/new-file.md\\") | 20 (-)
+
+
+            <details>
+              <summary>View Detailed Metrics</summary>
+
+            🟢 - Shows an _increase_ in readability
+            🔴 - Shows a _decrease_ in readability
+
+            Path | Readability | FRE | GF | ARI | CLI | DCRS
+            --- | --- | --- | --- | --- | --- | ---
+            [file-1.md](https://github.com/repo-name/blob/commit-sha/./folder/file-1.md \\"./folder/file-1.md\\") | 10 | 10 | 10 | 10 | 10 | 10
+            &nbsp; | 🟢 +1 | 🟢 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1
+            [file-2.md](https://github.com/repo-name/blob/commit-sha/./folder/file-2.md \\"./folder/file-2.md\\") | 5 | 5 | 5 | 5 | 5 | 5
+            &nbsp; | 🔴 -1 | 🔴 -1 | 🟢 -1 | 🟢 -1 | 🟢 -1 | 🟢 -1
+            [file-3.md](https://github.com/repo-name/blob/commit-sha/./folder/file-3.md \\"./folder/file-3.md\\") | 15 | 15 | 15 | 15 | 15 | 15
+            &nbsp; | 🟢 +0 | 🟢 +0 | 🟢 0 | 🟢 0 | 🟢 0 | 🟢 0
+            [new-file.md](https://github.com/repo-name/blob/commit-sha/./folder/new-file.md \\"./folder/new-file.md\\") | 20 | 20 | 20 | 20 | 20 | 20
+            &nbsp; | - | - | - | - | - | -
+
+
+            Averages:
+
+            &nbsp; | Readability | FRE | GF | ARI | CLI | DCRS
+            --- | --- | --- | --- | --- | --- | ---
+            Average | 1 | 1 | 1 | 1 | 1 | 1
+            &nbsp; | 🟢 +1 | 🟢 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1
+
 
             <details>
               <summary>View Metric Targets</summary>
@@ -55,36 +90,13 @@ describe('reportToComment', () => {
             --- | --- | ---
             Flesch Reading Ease | 100 (very easy read) to 0 (extremely difficult read) | 60
             Gunning Fog | 6 (very easy read) to 17 (extremely difficult read) | 8 or less
-            SMOG Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less
             Auto. Read. Index | 6 (very easy read) to 14 (extremely difficult read) | 8 or less
             Coleman Liau Index | 6 (very easy read) to 17 (extremely difficult read) | 8 or less
-            Linsear Write | 0 (very easy read) to 11 (extremely difficult read) | 8 or less
             Dale-Chall Readability | 4.9 (very easy read) to 9.9 (extremely difficult read) | 6.9 or less
 
             </details>
 
-            🟢 - Shows an _increase_ in readability
-            🔴 - Shows a _decrease_ in readability
-
-            Path | FRE | GF | SMOG | ARI | CLI | LWF | DCRS
-            --- | --- | --- | --- | --- | --- | --- | ---
-            [file-1.md](https://github.com/repo-name/blob/commit-sha/./folder/file-1.md \\"./folder/file-1.md\\") | 10 | 10 | 10 | 10 | 10 | 10 | 10
-            &nbsp; | 🟢 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1
-            [file-2.md](https://github.com/repo-name/blob/commit-sha/./folder/file-2.md \\"./folder/file-2.md\\") | 5 | 5 | 5 | 5 | 5 | 5 | 5
-            &nbsp; | 🔴 -1 | 🟢 -1 | 🟢 -1 | 🟢 -1 | 🟢 -1 | 🟢 -1 | 🟢 -1
-            [file-3.md](https://github.com/repo-name/blob/commit-sha/./folder/file-3.md \\"./folder/file-3.md\\") | 15 | 15 | 15 | 15 | 15 | 15 | 15
-            &nbsp; | 🟢 +0 | 🟢 0 | 🟢 0 | 🟢 0 | 🟢 0 | 🟢 0 | 🟢 0
-            [new-file.md](https://github.com/repo-name/blob/commit-sha/./folder/new-file.md \\"./folder/new-file.md\\") | 20 | 20 | 20 | 20 | 20 | 20 | 20
-            &nbsp; | - | - | - | - | - | - | -
-
-
-            Overall average:
-
-            &nbsp; | FRE | GF | SMOG | ARI | CLI | LWF | DCRS
-            --- | --- | --- | --- | --- | --- | --- | ---
-            Average | 1 | 1 | 1 | 1 | 1 | 1 | 1
-            &nbsp; | 🟢 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1 | 🔴 +1
-
+            </details>
             "
         `);
     });

--- a/src/readability.js
+++ b/src/readability.js
@@ -159,11 +159,15 @@ function createOverallReadabilityScore(normalizeScores){
         colemanLiauIndex: 0.1831723411,
     };
 
-    return (normalizeScores.fleschReadingEase * weights.fleschReadingEase) +
-        (normalizeScores.gunningFog * weights.gunningFog) +
-        (normalizeScores.automatedReadabilityIndex * weights.automatedReadabilityIndex) +
-        (normalizeScores.daleChallReadabilityScore * weights.daleChallReadabilityScore) +
-        (normalizeScores.colemanLiauIndex * weights.colemanLiauIndex);
+    // The reability score from 0 to 1.0
+    const normalizedReadabilityScore = (normalizeScores.fleschReadingEase * weights.fleschReadingEase) +
+    (normalizeScores.gunningFog * weights.gunningFog) +
+    (normalizeScores.automatedReadabilityIndex * weights.automatedReadabilityIndex) +
+    (normalizeScores.daleChallReadabilityScore * weights.daleChallReadabilityScore) +
+    (normalizeScores.colemanLiauIndex * weights.colemanLiauIndex);
+
+    // Scale the score from 0 to 100
+    return 100 * normalizedReadabilityScore;
 }
 
 // Calculates the average of a particular property value, given an array of objects

--- a/src/readability.js
+++ b/src/readability.js
@@ -150,7 +150,7 @@ function normalizeScores(scores) {
     };
 }
 
-function calculateReadabilityScore(normalizeScores){
+function calculateReadabilityScore(normalizedScores){
     const weights = {
         fleschReadingEase: 0.1653977378,
         gunningFog: 0.2228367277,
@@ -160,11 +160,11 @@ function calculateReadabilityScore(normalizeScores){
     };
 
     // The reability score from 0 to 1.0
-    const normalizedReadabilityScore = (normalizeScores.fleschReadingEase * weights.fleschReadingEase) +
-    (normalizeScores.gunningFog * weights.gunningFog) +
-    (normalizeScores.automatedReadabilityIndex * weights.automatedReadabilityIndex) +
-    (normalizeScores.daleChallReadabilityScore * weights.daleChallReadabilityScore) +
-    (normalizeScores.colemanLiauIndex * weights.colemanLiauIndex);
+    const normalizedReadabilityScore = (normalizedScores.fleschReadingEase * weights.fleschReadingEase) +
+    (normalizedScores.gunningFog * weights.gunningFog) +
+    (normalizedScores.automatedReadabilityIndex * weights.automatedReadabilityIndex) +
+    (normalizedScores.daleChallReadabilityScore * weights.daleChallReadabilityScore) +
+    (normalizedScores.colemanLiauIndex * weights.colemanLiauIndex);
 
     // Scale the score from 0 to 100
     return 100 * normalizedReadabilityScore;

--- a/src/readability.js
+++ b/src/readability.js
@@ -113,7 +113,7 @@ function scoreText(text) {
     };
 }
 
-// Returns scores for a given string
+// Returns each score normalized to a value between 0 and 1
 function normalizeScores(scores) {
     const ranges = {
         fleschReadingEase: {
@@ -150,7 +150,7 @@ function normalizeScores(scores) {
     };
 }
 
-function createOverallReadabilityScore(normalizeScores){
+function calculateReadabilityScore(normalizeScores){
     const weights = {
         fleschReadingEase: 0.1653977378,
         gunningFog: 0.2228367277,
@@ -219,12 +219,12 @@ export function calculateReadability(globPath) {
         const stripped = preprocessMarkdown(markdown);
         const scores = scoreText(stripped);
         const normalized = normalizeScores(scores);
-        const overallReadabilityScore = createOverallReadabilityScore(normalized);
+        const readabilityScore = calculateReadabilityScore(normalized);
 
         return {
             name: filePath,
             scores: {
-                overallReadabilityScore, 
+                readabilityScore, 
                 ...scores
             }
         };


### PR DESCRIPTION
This PR updates the readability reporter to report a new unified "readability" metric as its main output, instead of the series of other readability scores.

The `readability` metric is a combination of the other metrics, weighted by results taken from our documentation.

Changes:
- Add readability score
- Add .gitattributes file to auto hide dist file changes in PRs
- Removed: SMOG and Linsear Write metrics. They are not included in the readability score and were trending in the wrong direction when we made positive changes.